### PR TITLE
Add csv gem and update UI styles for tables in show view

### DIFF
--- a/.idea/copilot.data.migration.ask.xml
+++ b/.idea/copilot.data.migration.ask.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AskMigrationStateService">
+    <option name="migrationStatus" value="COMPLETED" />
+  </component>
+</project>

--- a/.idea/copilot.data.migration.ask2agent.xml
+++ b/.idea/copilot.data.migration.ask2agent.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Ask2AgentMigrationStateService">
+    <option name="migrationStatus" value="COMPLETED" />
+  </component>
+</project>

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,14 +22,33 @@ class ApplicationController < ActionController::Base
 
   private
 
+  # ruby
   def set_tenant
-    # ActsAsTenant.current_tenant = Client.find_by(name: request.domain)
-    client = Client.find_by(name: request.domain)
-    if client
-      ActsAsTenant.current_tenant = client
+    subdomain = request.subdomains.first
+    if subdomain.present?
+      client = Client.find_by(name: subdomain)
+      if client
+        ActsAsTenant.current_tenant = client
+      else
+        fallback_client = Client.find_by(name: 'localhost') || Client.first
+        if fallback_client
+          ActsAsTenant.current_tenant = fallback_client
+          Rails.logger.warn "Tenant not found for subdomain '#{subdomain}', using fallback client '#{fallback_client.name}'."
+        else
+          Rails.logger.error "No suitable tenant found for subdomain '#{subdomain}' or fallback."
+          redirect_to root_path, alert: "Tenant not found for subdomain '#{subdomain}'." and return
+        end
+      end
     else
-      # You can customize this behavior as needed (e.g., render 404, redirect, etc.)
-      redirect_to root_path, alert: "Tenant not found for domain '#{request.domain}'." and return
+      # No subdomain, fallback to default client
+      fallback_client = Client.find_by(name: 'localhost') || Client.first
+      if fallback_client
+        ActsAsTenant.current_tenant = fallback_client
+        Rails.logger.warn "No subdomain present, using fallback client '#{fallback_client.name}'."
+      else
+        Rails.logger.error 'No suitable tenant found for request with no subdomain.'
+        redirect_to root_path, alert: 'Tenant not found for request with no subdomain.' and return
+      end
     end
   end
 end

--- a/app/models/home.rb
+++ b/app/models/home.rb
@@ -1,5 +1,6 @@
 class Home < ApplicationRecord
   acts_as_tenant(:client)
+  belongs_to :client, optional: true
   belongs_to :user
   has_one_attached :document
 

--- a/db/migrate/20250922125224_add_client_id_to_homes.rb
+++ b/db/migrate/20250922125224_add_client_id_to_homes.rb
@@ -1,0 +1,6 @@
+class AddClientIdToHomes < ActiveRecord::Migration[8.0]
+  def change
+    add_reference :homes, :client, null: true, foreign_key: true, type: :uuid
+
+  end
+end

--- a/db/migrate/20250925112131_add_client_to_roles.rb
+++ b/db/migrate/20250925112131_add_client_to_roles.rb
@@ -1,0 +1,5 @@
+class AddClientToRoles < ActiveRecord::Migration[8.0]
+  def change
+    add_reference :roles, :client, null: true, foreign_key: true, type: :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_12_142218) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_25_112131) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -68,6 +68,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_12_142218) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "user_id", null: false
+    t.uuid "client_id"
+    t.index ["client_id"], name: "index_homes_on_client_id"
     t.index ["user_id"], name: "index_homes_on_user_id"
   end
 
@@ -77,6 +79,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_12_142218) do
     t.uuid "resource_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "client_id"
+    t.index ["client_id"], name: "index_roles_on_client_id"
     t.index ["name", "resource_type", "resource_id"], name: "index_roles_on_name_and_resource_type_and_resource_id"
     t.index ["resource_type", "resource_id"], name: "index_roles_on_resource"
   end
@@ -136,6 +140,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_12_142218) do
   add_foreign_key "accounts", "clients"
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "homes", "clients"
   add_foreign_key "homes", "users"
+  add_foreign_key "roles", "clients"
   add_foreign_key "users", "clients"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,3 +7,16 @@
 #   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
 #     MovieGenre.find_or_create_by!(name: genre_name)
 #   end
+
+client = Client.find_or_create_by!(name: 'howel')
+Role.find_or_create_by!(name: 'admin')
+
+user = User.find_or_initialize_by(email: 'admin@craftsilicon.com')
+user.password = 'password'
+user.confirmed_at = DateTime.now
+user.confirmation_sent_at = DateTime.now
+user.first_name = 'Jay'
+user.last_name = 'Admin'
+user.client = client
+user.save!
+user.add_role(:admin)


### PR DESCRIPTION
This pull request introduces multi-tenancy improvements and database changes to support associating tenants (`Client`) with `Home` and `Role` records. It also updates the tenant resolution logic to handle subdomains and fallback scenarios more robustly. Additionally, seed data and migration status files are added for development convenience.

**Multi-tenancy and tenant resolution:**

* Enhanced the `set_tenant` method in `application_controller.rb` to resolve tenants based on subdomain, with fallback to a default client and improved error handling and logging.

**Database schema changes:**

* Added `client_id` as an optional foreign key to the `homes` and `roles` tables via new migrations, and updated the schema accordingly. [[1]](diffhunk://#diff-079d0de193a6b6fdf171804fd55dba4f991a328b828d2bf179813d973e676911R1-R6) [[2]](diffhunk://#diff-9ddc22f3c67cc95c0baefc73b656c671b6d17fd62b7ca96b321b61aa275d4d57R1-R5) [[3]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3R71-R72) [[4]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3R82-R83) [[5]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3R143-R145)
* Updated the `Home` model to include an optional `belongs_to :client` association.

**Seed and migration status updates:**

* Added seed data for a default `Client`, an `admin` role, and a sample admin user associated with the client, including role assignment.
* Added IDE migration status files `.idea/copilot.data.migration.ask.xml` and `.idea/copilot.data.migration.ask2agent.xml` to indicate completed migration status. [[1]](diffhunk://#diff-d5798d2ba7d178b4af1dce13148240df97ba7a3557c0c7eefb68f33bb00ab567R1-R6) [[2]](diffhunk://#diff-e5d9a6c923b4b054af0508e997183314be9401f8315f3c3147c88053bc1cf704R1-R6)