### PR TITLE
Ruby fix

### DIFF
--- a/.idea/melpay.iml
+++ b/.idea/melpay.iml
@@ -28,17 +28,17 @@
     </content>
     <orderEntry type="jdk" jdkName="rbenv: 3.3.5" jdkType="RUBY_SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" scope="PROVIDED" name="actioncable (v8.0.2.1, rbenv: 3.3.5) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="actionmailbox (v8.0.2.1, rbenv: 3.3.5) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="actionmailer (v8.0.2.1, rbenv: 3.3.5) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="actionpack (v8.0.2.1, rbenv: 3.3.5) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="actiontext (v8.0.2.1, rbenv: 3.3.5) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="actionview (v8.0.2.1, rbenv: 3.3.5) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="activejob (v8.0.2.1, rbenv: 3.3.5) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="activemodel (v8.0.2.1, rbenv: 3.3.5) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="activerecord (v8.0.2.1, rbenv: 3.3.5) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="activestorage (v8.0.2.1, rbenv: 3.3.5) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="activesupport (v8.0.2.1, rbenv: 3.3.5) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="actioncable (v8.0.3, rbenv: 3.3.5) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="actionmailbox (v8.0.3, rbenv: 3.3.5) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="actionmailer (v8.0.3, rbenv: 3.3.5) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="actionpack (v8.0.3, rbenv: 3.3.5) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="actiontext (v8.0.3, rbenv: 3.3.5) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="actionview (v8.0.3, rbenv: 3.3.5) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="activejob (v8.0.3, rbenv: 3.3.5) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="activemodel (v8.0.3, rbenv: 3.3.5) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="activerecord (v8.0.3, rbenv: 3.3.5) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="activestorage (v8.0.3, rbenv: 3.3.5) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="activesupport (v8.0.3, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="acts_as_tenant (v1.0.1, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="addressable (v2.8.7, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="ast (v2.4.3, rbenv: 3.3.5) [gem]" level="application" />
@@ -55,7 +55,7 @@
     <orderEntry type="library" scope="PROVIDED" name="capybara (v3.40.0, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="chartkick (v5.2.0, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="concurrent-ruby (v1.3.5, rbenv: 3.3.5) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="connection_pool (v2.5.3, rbenv: 3.3.5) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="connection_pool (v2.5.4, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="crass (v1.0.6, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="csv (v3.3.5, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="date (v3.4.1, rbenv: 3.3.5) [gem]" level="application" />
@@ -69,7 +69,7 @@
     <orderEntry type="library" scope="PROVIDED" name="erubi (v1.13.1, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="et-orbi (v1.2.11, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="fugit (v1.11.1, rbenv: 3.3.5) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="globalid (v1.2.1, rbenv: 3.3.5) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="globalid (v1.3.0, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="groupdate (v6.7.0, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="hashie (v5.0.0, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="i18n (v1.14.7, rbenv: 3.3.5) [gem]" level="application" />
@@ -84,12 +84,12 @@
     <orderEntry type="library" scope="PROVIDED" name="logger (v1.7.0, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="loofah (v2.24.1, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="mail (v2.8.1, rbenv: 3.3.5) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="marcel (v1.0.4, rbenv: 3.3.5) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="marcel (v1.1.0, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="matrix (v0.4.3, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="mini_mime (v1.1.5, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="minitest (v5.25.5, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="msgpack (v1.8.0, rbenv: 3.3.5) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="net-imap (v0.5.9, rbenv: 3.3.5) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="net-imap (v0.5.10, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="net-pop (v0.1.2, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="net-protocol (v0.2.2, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="net-scp (v4.1.0, rbenv: 3.3.5) [gem]" level="application" />
@@ -97,7 +97,7 @@
     <orderEntry type="library" scope="PROVIDED" name="net-smtp (v0.5.1, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="net-ssh (v7.3.0, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="nio4r (v2.7.4, rbenv: 3.3.5) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="nokogiri (v1.18.9, rbenv: 3.3.5) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="nokogiri (v1.18.10, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="omniauth (v2.1.3, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="orm_adapter (v0.5.0, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="ostruct (v0.6.3, rbenv: 3.3.5) [gem]" level="application" />
@@ -107,21 +107,21 @@
     <orderEntry type="library" scope="PROVIDED" name="pp (v0.6.2, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="prettyprint (v0.2.0, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="prism (v1.4.0, rbenv: 3.3.5) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="propshaft (v1.2.1, rbenv: 3.3.5) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="propshaft (v1.3.1, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="psych (v5.2.6, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="public_suffix (v6.0.2, rbenv: 3.3.5) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="puma (v7.0.3, rbenv: 3.3.5) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="puma (v7.0.4, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="raabro (v1.4.0, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="racc (v1.8.1, rbenv: 3.3.5) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rack (v3.2.0, rbenv: 3.3.5) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rack (v3.2.1, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="rack-protection (v4.1.1, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="rack-session (v2.1.1, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="rack-test (v2.2.0, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="rackup (v2.2.1, rbenv: 3.3.5) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rails (v8.0.2.1, rbenv: 3.3.5) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rails (v8.0.3, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="rails-dom-testing (v2.3.0, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="rails-html-sanitizer (v1.6.2, rbenv: 3.3.5) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="railties (v8.0.2.1, rbenv: 3.3.5) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="railties (v8.0.3, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="rainbow (v3.1.1, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="rake (v13.3.0, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="rdoc (v6.14.2, rbenv: 3.3.5) [gem]" level="application" />
@@ -140,8 +140,8 @@
     <orderEntry type="library" scope="PROVIDED" name="rubyzip (v2.4.1, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="securerandom (v0.4.1, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="selenium-webdriver (v4.35.0, rbenv: 3.3.5) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="sentry-rails (v5.27.0, rbenv: 3.3.5) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="sentry-ruby (v5.27.0, rbenv: 3.3.5) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="sentry-rails (v5.27.1, rbenv: 3.3.5) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="sentry-ruby (v5.27.1, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="solid_cable (v3.0.12, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="solid_cache (v1.0.7, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="solid_queue (v1.2.1, rbenv: 3.3.5) [gem]" level="application" />
@@ -153,6 +153,7 @@
     <orderEntry type="library" scope="PROVIDED" name="thor (v1.4.0, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="thruster (v0.1.14, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="timeout (v0.4.3, rbenv: 3.3.5) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="tsort (v0.2.0, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="turbo-rails (v2.0.16, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="tzinfo (v2.0.6, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="unicode-display_width (v3.1.4, rbenv: 3.3.5) [gem]" level="application" />

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,8 +3,6 @@ class ApplicationController < ActionController::Base
   allow_browser versions: :modern
   before_action :update_allowed_parameters, if: :devise_controller?
   before_action :authenticate_user!, except: %i[new create]
-  set_current_tenant_through_filter
-  before_action :set_tenant
 
   def update_allowed_parameters
     devise_parameter_sanitizer.permit(:sign_up) { |u| u.permit(:first_name, :last_name, :email, :password) }
@@ -18,37 +16,5 @@ class ApplicationController < ActionController::Base
     return unless user_signed_in? && !session[:two_factor_authenticated]
 
     redirect_to send_otp_two_factor_path
-  end
-
-  private
-
-  # ruby
-  def set_tenant
-    subdomain = request.subdomains.first
-    if subdomain.present?
-      client = Client.find_by(name: subdomain)
-      if client
-        ActsAsTenant.current_tenant = client
-      else
-        fallback_client = Client.find_by(name: 'localhost') || Client.first
-        if fallback_client
-          ActsAsTenant.current_tenant = fallback_client
-          Rails.logger.warn "Tenant not found for subdomain '#{subdomain}', using fallback client '#{fallback_client.name}'."
-        else
-          Rails.logger.error "No suitable tenant found for subdomain '#{subdomain}' or fallback."
-          redirect_to root_path, alert: "Tenant not found for subdomain '#{subdomain}'." and return
-        end
-      end
-    else
-      # No subdomain, fallback to default client
-      fallback_client = Client.find_by(name: 'localhost') || Client.first
-      if fallback_client
-        ActsAsTenant.current_tenant = fallback_client
-        Rails.logger.warn "No subdomain present, using fallback client '#{fallback_client.name}'."
-      else
-        Rails.logger.error 'No suitable tenant found for request with no subdomain.'
-        redirect_to root_path, alert: 'Tenant not found for request with no subdomain.' and return
-      end
-    end
   end
 end

--- a/app/models/home.rb
+++ b/app/models/home.rb
@@ -1,5 +1,4 @@
 class Home < ApplicationRecord
-  acts_as_tenant(:client)
   belongs_to :client, optional: true
   belongs_to :user
   has_one_attached :document

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,6 +1,4 @@
 class Role < ApplicationRecord
-  acts_as_tenant(:client)
-
   has_and_belongs_to_many :users, join_table: :users_roles
 
   belongs_to :resource,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,4 @@
 class User < ApplicationRecord
-  acts_as_tenant(:client)
-
   rolify
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,7 @@ class User < ApplicationRecord
          :validatable, :confirmable, :lockable, :timeoutable, :trackable, :invitable
 
   has_many :homes, dependent: :destroy
+  belongs_to :client
   after_create :default_role
 
   def default_role

--- a/db/migrate/20250912135050_add_client_id_to_user.rb
+++ b/db/migrate/20250912135050_add_client_id_to_user.rb
@@ -1,5 +1,0 @@
-class AddClientIdToUser < ActiveRecord::Migration[8.0]
-  def change
-    add_reference :users, :client, null: true, foreign_key: true, type: :uuid
-  end
-end

--- a/db/migrate/20250922125224_add_client_id_to_homes.rb
+++ b/db/migrate/20250922125224_add_client_id_to_homes.rb
@@ -1,6 +1,0 @@
-class AddClientIdToHomes < ActiveRecord::Migration[8.0]
-  def change
-    add_reference :homes, :client, null: true, foreign_key: true, type: :uuid
-
-  end
-end

--- a/db/migrate/20250925112131_add_client_to_roles.rb
+++ b/db/migrate/20250925112131_add_client_to_roles.rb
@@ -1,5 +1,0 @@
-class AddClientToRoles < ActiveRecord::Migration[8.0]
-  def change
-    add_reference :roles, :client, null: true, foreign_key: true, type: :uuid
-  end
-end

--- a/db/migrate/20250927092557_add_client_to_user.rb
+++ b/db/migrate/20250927092557_add_client_to_user.rb
@@ -1,0 +1,5 @@
+class AddClientToUser < ActiveRecord::Migration[8.0]
+  def change
+    add_reference :users, :client, null: true, foreign_key: true, type: :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_12_142218) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_27_092557) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -114,6 +114,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_12_142218) do
     t.integer "invitations_count", default: 0
     t.string "first_name"
     t.string "last_name"
+    t.uuid "client_id"
+    t.index ["client_id"], name: "index_users_on_client_id"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
@@ -135,4 +137,5 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_12_142218) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "homes", "users"
+  add_foreign_key "users", "clients"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_25_112131) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_12_142218) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -68,8 +68,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_25_112131) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "user_id", null: false
-    t.uuid "client_id"
-    t.index ["client_id"], name: "index_homes_on_client_id"
     t.index ["user_id"], name: "index_homes_on_user_id"
   end
 
@@ -79,8 +77,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_25_112131) do
     t.uuid "resource_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.uuid "client_id"
-    t.index ["client_id"], name: "index_roles_on_client_id"
     t.index ["name", "resource_type", "resource_id"], name: "index_roles_on_name_and_resource_type_and_resource_id"
     t.index ["resource_type", "resource_id"], name: "index_roles_on_resource"
   end
@@ -116,10 +112,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_25_112131) do
     t.string "invited_by_type"
     t.bigint "invited_by_id"
     t.integer "invitations_count", default: 0
-    t.uuid "client_id"
     t.string "first_name"
     t.string "last_name"
-    t.index ["client_id"], name: "index_users_on_client_id"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
@@ -140,8 +134,5 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_25_112131) do
   add_foreign_key "accounts", "clients"
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
-  add_foreign_key "homes", "clients"
   add_foreign_key "homes", "users"
-  add_foreign_key "roles", "clients"
-  add_foreign_key "users", "clients"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,15 +8,11 @@
 #     MovieGenre.find_or_create_by!(name: genre_name)
 #   end
 
-client = Client.find_or_create_by!(name: 'howel')
+# ruby
+
+# ruby
+
 Role.find_or_create_by!(name: 'admin')
 
-user = User.find_or_initialize_by(email: 'admin@craftsilicon.com')
-user.password = 'password'
-user.confirmed_at = DateTime.now
-user.confirmation_sent_at = DateTime.now
-user.first_name = 'Jay'
-user.last_name = 'Admin'
-user.client = client
-user.save!
+user = User.create!(email: 'abolger254@gmail.com', password: 'password', confirmed_at: DateTime.now, confirmation_sent_at: DateTime.now, first_name: 'Jay', last_name: 'Admin')
 user.add_role(:admin)


### PR DESCRIPTION
This pull request removes multi-tenancy support based on the `acts_as_tenant` gem from the codebase. The most significant changes are the removal of tenant-scoping logic from models and controllers, as well as related database migrations and schema references. Additionally, there are minor dependency version bumps in the `.idea/melpay.iml` file.

Removal of multi-tenancy logic:

* The `acts_as_tenant(:client)` line was removed from the `Home`, `Role`, and `User` models, eliminating tenant scoping at the model level. [[1]](diffhunk://#diff-d9fb6e88a90909f09afa46698179e9276725e3a9761c3ca51fb7c7148c163045L2) [[2]](diffhunk://#diff-81647a521a55f3b496fdef1a196a4cee6502fa175f158d6eb8db6074c16966bcL2-L3) [[3]](diffhunk://#diff-9802ca3c9c4cf89904fd44bc114e35ebdf2c5dd3d5b645491e2b253e1afef29bL2-R9)
* The tenant-setting logic (`set_tenant` method and related filters) was removed from `ApplicationController`, so requests are no longer scoped to tenants based on subdomain. [[1]](diffhunk://#diff-766c34fd6533171eaf54300c153f89d6002c35c02cfc9c5b219251f85180ad07L6-L7) [[2]](diffhunk://#diff-766c34fd6533171eaf54300c153f89d6002c35c02cfc9c5b219251f85180ad07L22-L53)

Database and migration clean-up:

* Migrations adding `client_id` references to `homes` and `roles` were deleted, and the corresponding foreign key and index entries were removed from `db/schema.rb`. [[1]](diffhunk://#diff-079d0de193a6b6fdf171804fd55dba4f991a328b828d2bf179813d973e676911L1-L6) [[2]](diffhunk://#diff-9ddc22f3c67cc95c0baefc73b656c671b6d17fd62b7ca96b321b61aa275d4d57L1-L5) [[3]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3L71-L72) [[4]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3L82-L83) [[5]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3L143-L145)
* The migration for adding `client_id` to `users` was renamed and updated, with schema changes reflecting the new order and placement of the column. [[1]](diffhunk://#diff-925879e19c30eeab7edbd3cb07e1378d4080322b9db9ee7ca93bfa305f75b815L1-R1) [[2]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3L119-R117)

Other updates:

* Minor dependency version updates in `.idea/melpay.iml`, including upgrades for Rails, `connection_pool`, `globalid`, `marcel`, `net-imap`, `nokogiri`, `propshaft`, `puma`, `rack`, `sentry-rails`, and `sentry-ruby`, and addition of `tsort`. [[1]](diffhunk://#diff-a6bbf75510905937b7564b563ffd9138738a520ac253b5155bab056949492555L31-R41) [[2]](diffhunk://#diff-a6bbf75510905937b7564b563ffd9138738a520ac253b5155bab056949492555L58-R58) [[3]](diffhunk://#diff-a6bbf75510905937b7564b563ffd9138738a520ac253b5155bab056949492555L72-R72) [[4]](diffhunk://#diff-a6bbf75510905937b7564b563ffd9138738a520ac253b5155bab056949492555L87-R100) [[5]](diffhunk://#diff-a6bbf75510905937b7564b563ffd9138738a520ac253b5155bab056949492555L110-R124) [[6]](diffhunk://#diff-a6bbf75510905937b7564b563ffd9138738a520ac253b5155bab056949492555L143-R144) [[7]](diffhunk://#diff-a6bbf75510905937b7564b563ffd9138738a520ac253b5155bab056949492555R156)

Seed data adjustment:

* The seed file was updated to remove tenant assignment from the initial user creation, reflecting the removal of tenant logic.