### PR TITLE
Final commission add on

### DIFF
--- a/.idea/melpay.iml
+++ b/.idea/melpay.iml
@@ -99,7 +99,7 @@
     <orderEntry type="library" scope="PROVIDED" name="net-ssh (v7.3.0, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="nio4r (v2.7.4, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="nokogiri (v1.18.10, rbenv: 3.3.5) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="omniauth (v2.1.3, rbenv: 3.3.5) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="omniauth (v2.1.4, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="orm_adapter (v0.5.0, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="ostruct (v0.6.3, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="parallel (v1.27.0, rbenv: 3.3.5) [gem]" level="application" />
@@ -129,20 +129,20 @@
     <orderEntry type="library" scope="PROVIDED" name="regexp_parser (v2.10.0, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="reline (v0.6.2, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="responders (v3.1.1, rbenv: 3.3.5) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rexml (v3.4.1, rbenv: 3.3.5) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rexml (v3.4.4, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="rolify (v6.0.1, rbenv: 3.3.5) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="roo (v2.10.1, rbenv: 3.3.5) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="roo (v3.0.0, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="rubocop (v1.79.1, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="rubocop-ast (v1.46.0, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="rubocop-performance (v1.25.0, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="rubocop-rails (v2.32.0, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="rubocop-rails-omakase (v1.1.0, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="ruby-progressbar (v1.13.0, rbenv: 3.3.5) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rubyzip (v2.4.1, rbenv: 3.3.5) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rubyzip (v3.1.1, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="securerandom (v0.4.1, rbenv: 3.3.5) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="selenium-webdriver (v4.35.0, rbenv: 3.3.5) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="sentry-rails (v5.27.1, rbenv: 3.3.5) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="sentry-ruby (v5.27.1, rbenv: 3.3.5) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="selenium-webdriver (v4.36.0, rbenv: 3.3.5) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="sentry-rails (v5.28.0, rbenv: 3.3.5) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="sentry-ruby (v5.28.0, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="solid_cable (v3.0.12, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="solid_cache (v1.0.7, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="solid_queue (v1.2.1, rbenv: 3.3.5) [gem]" level="application" />
@@ -155,7 +155,7 @@
     <orderEntry type="library" scope="PROVIDED" name="thruster (v0.1.14, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="timeout (v0.4.3, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="tsort (v0.2.0, rbenv: 3.3.5) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="turbo-rails (v2.0.16, rbenv: 3.3.5) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="turbo-rails (v2.0.17, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="tzinfo (v2.0.6, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="unicode-display_width (v3.1.4, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="unicode-emoji (v4.0.4, rbenv: 3.3.5) [gem]" level="application" />

--- a/app/views/accounts/new.html.erb
+++ b/app/views/accounts/new.html.erb
@@ -7,4 +7,4 @@
     <%= link_to "Cancel", client_path(@client),
     class: "text-red-700 hover:text-red-900 dark:text-red-400 dark:hover:text-red-300 hover:underline" %>
   </div>
-</div>@
+</div>

--- a/app/views/interest_rates/index.html.erb
+++ b/app/views/interest_rates/index.html.erb
@@ -10,7 +10,7 @@
   <% end %>
 
   <div class="flex items-center justify-between mb-6">
-    <h1 class="text-2xl font-semibold text-gray-900">Interest Rates</h1>
+    <h1 class="text-2xl font-semibold text-gray-900">Commission Rates</h1>
     <div>
       <%= link_to "Manage Rates", manage_interest_rates_path, class: "inline-block px-4 py-2 bg-indigo-600 text-white rounded shadow hover:bg-indigo-700" %>
     </div>
@@ -21,7 +21,7 @@
     <div class="flex items-center justify-between">
       <div>
         <p class="text-sm font-medium text-blue-900">
-          <strong>Global Default Rate:</strong>
+          <strong>Global Default Commission</strong>
           <span class="ml-2 text-lg font-semibold"><%= number_to_percentage(@global_rate, precision: 2) %></span>
         </p>
         <p class="text-sm text-blue-700 mt-1">

--- a/app/views/interest_rates/manage.html.erb
+++ b/app/views/interest_rates/manage.html.erb
@@ -10,8 +10,8 @@
   <% end %>
 
   <div class="flex items-center justify-between mb-6">
-    <h1 class="text-2xl font-semibold">Interest Rate Management</h1>
-    <%= link_to "Back to Rates", interest_rates_path, class: "text-gray-600 hover:text-gray-900" %>
+    <h1 class="text-2xl font-semibold">Commission Management</h1>
+    <%= link_to "Back to Commission", interest_rates_path, class: "text-gray-600 hover:text-gray-900" %>
   </div>
 
   <div class="grid grid-cols-1 gap-6">
@@ -19,7 +19,7 @@
     <div class="bg-white p-6 rounded-lg shadow border">
       <h2 class="text-lg font-medium mb-4 flex items-center">
         <span class="w-3 h-3 bg-blue-500 rounded-full mr-2"></span>
-        Global Interest Rate
+        Global Commision
       </h2>
       
       <%= form_with model: @system_setting, url: update_global_interest_rates_path, method: :put, local: true do |f| %>
@@ -45,7 +45,7 @@
     <div class="bg-white p-6 rounded-lg shadow border">
       <h2 class="text-lg font-medium mb-4 flex items-center">
         <span class="w-3 h-3 bg-yellow-500 rounded-full mr-2"></span>
-        Set Custom Interest Rate for Client
+        Set Custom Commission Rate for Client
       </h2>
 
       <%= form_with url: update_custom_interest_rates_path, method: :put, local: true do |f| %>
@@ -68,7 +68,7 @@
         </div>
 
         <div class="mt-4">
-          <%= f.submit "Set Custom Rate", class: "px-4 py-2 bg-yellow-600 text-white rounded hover:bg-yellow-700" %>
+          <%= f.submit "Set Custom Commission", class: "px-4 py-2 bg-yellow-600 text-white rounded hover:bg-yellow-700" %>
         </div>
       <% end %>
     </div>

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -29,7 +29,7 @@
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
               <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 18.75a60.07 60.07 0 0 1 15.797 2.101c.727.198 1.453-.342 1.453-1.096V18.75M3.75 4.5v.75A.75.75 0 0 1 3 6h-.75m0 0v-.375c0-.621.504-1.125 1.125-1.125H20.25M2.25 6v9m18-10.5v.75c0 .414.336.75.75.75h.75m-1.5-1.5h.375c.621 0 1.125.504 1.125 1.125v9.75c0 .621-.504 1.125-1.125 1.125h-.375m1.5-1.5H21a.75.75 0 0 0-.75.75v.75m0 0H3.75m0 0h-.375a1.125 1.125 0 0 1-1.125-1.125V15m1.5 1.5v-.75A.75.75 0 0 0 3 15h-.75M15 10.5a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm3 0h.008v.008H18V10.5Zm-12 0h.008v.008H6V10.5Z" />
             </svg>
-            <span class="ms-3">Interest Rates</span>
+            <span class="ms-3">Commission</span>
           </div>
         </li>
       <% end %>


### PR DESCRIPTION
This pull request primarily focuses on renaming "Interest Rates" to "Commission" throughout the user interface, along with updating several gem dependencies to their latest versions in the project configuration. The terminology change is reflected in various headings, labels, and navigation elements to ensure consistency across the application.

**UI Terminology Updates:**

* Changed all references of "Interest Rates" to "Commission" or "Commission Rates" in the following places:
  - Main heading and global rate label in `interest_rates/index.html.erb` [[1]](diffhunk://#diff-d4e6743e0bb0485d481fcb18731aab69cfa52761ed1887801a41e4fb4a5e4854L13-R13) [[2]](diffhunk://#diff-d4e6743e0bb0485d481fcb18731aab69cfa52761ed1887801a41e4fb4a5e4854L24-R24)
  - Headings, labels, and button text in `interest_rates/manage.html.erb` [[1]](diffhunk://#diff-7b4c8f2f7bf515c6029a023fba84a2352527826d9bbe2e574bb98779f03f7414L13-R22) [[2]](diffhunk://#diff-7b4c8f2f7bf515c6029a023fba84a2352527826d9bbe2e574bb98779f03f7414L48-R48) [[3]](diffhunk://#diff-7b4c8f2f7bf515c6029a023fba84a2352527826d9bbe2e574bb98779f03f7414L71-R71)
  - Sidebar navigation label in `_sidebar.html.erb`

**Dependency Updates:**

* Upgraded several gem versions in `.idea/melpay.iml` to keep dependencies current:
  - `omniauth` to v2.1.4, `rexml` to v3.4.4, `roo` to v3.0.0, `rubyzip` to v3.1.1, `selenium-webdriver` to v4.36.0, `sentry-rails` and `sentry-ruby` to v5.28.0, and `turbo-rails` to v2.0.17 [[1]](diffhunk://#diff-a6bbf75510905937b7564b563ffd9138738a520ac253b5155bab056949492555L102-R102) [[2]](diffhunk://#diff-a6bbf75510905937b7564b563ffd9138738a520ac253b5155bab056949492555L132-R145) [[3]](diffhunk://#diff-a6bbf75510905937b7564b563ffd9138738a520ac253b5155bab056949492555L158-R158)

**Minor Fixes:**

* Fixed a stray character at the end of `accounts/new.html.erb`